### PR TITLE
fix(worker): validate message payloads and stop echoing upstream errors

### DIFF
--- a/my-chatbot/src/index.ts
+++ b/my-chatbot/src/index.ts
@@ -17,6 +17,12 @@ interface Env {
 	OPENAI_API_KEY: string;
 }
 
+// Request limits so malformed or oversized payloads are rejected
+// before they reach OpenAI
+const ALLOWED_ROLES = ["system", "user", "assistant"];
+const MAX_MESSAGES = 50;
+const MAX_CONTENT_LENGTH = 8000;
+
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
 	  try {
@@ -46,7 +52,27 @@ export default {
 			{ status: 400, headers: { "Content-Type": "application/json" } }
 		  );
 		}
-  
+
+	// Validate message contents before forwarding anything to OpenAI
+	if (requestData.messages.length === 0 || requestData.messages.length > MAX_MESSAGES) {
+		  return new Response(
+			JSON.stringify({ error: `'messages' must contain between 1 and ${MAX_MESSAGES} entries.` }),
+			{ status: 400, headers: { "Content-Type": "application/json" } }
+		  );
+		}
+	for (const message of requestData.messages) {
+		  if (!message || typeof message !== "object" ||
+			  !ALLOWED_ROLES.includes(message.role) ||
+			  typeof message.content !== "string" ||
+			  message.content.length === 0 ||
+			  message.content.length > MAX_CONTENT_LENGTH) {
+			return new Response(
+			  JSON.stringify({ error: `Each message needs a role (${ALLOWED_ROLES.join(", ")}) and a non-empty string content of at most ${MAX_CONTENT_LENGTH} characters.` }),
+			  { status: 400, headers: { "Content-Type": "application/json" } }
+			);
+		  }
+		}
+
 		// Send request to OpenAI API
 		const response = await fetch("https://api.openai.com/v1/chat/completions", {
 		  method: "POST",
@@ -54,14 +80,21 @@ export default {
 			"Content-Type": "application/json",
 			"Authorization": `Bearer ${env.OPENAI_API_KEY}`
 		  },
-		  body: JSON.stringify({ model: "gpt-3.5-turbo", messages: requestData.messages })
+		  body: JSON.stringify({
+			model: "gpt-3.5-turbo",
+			messages: requestData.messages.map((message: { role: string; content: string }) => ({
+			  role: message.role,
+			  content: message.content
+			}))
+		  })
 		});
-  
+
 		if (!response.ok) {
-		  const errorText = await response.text();
+		  // Log the upstream detail server-side; don't echo it to the client
+		  console.error('OpenAI API error:', response.status, await response.text());
 		  return new Response(
-			JSON.stringify({ error: "OpenAI API error", details: errorText }),
-			{ status: response.status, headers: { "Content-Type": "application/json" } }
+			JSON.stringify({ error: "Upstream API error." }),
+			{ status: 502, headers: { "Content-Type": "application/json" } }
 		  );
 		}
   
@@ -72,10 +105,10 @@ export default {
 		  headers: { "Content-Type": "application/json" }
 		});
 	  } catch (error: unknown) {
+		// Log the detail server-side; don't echo internals to the client
 		console.error('Server error:', error);
-		const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 		return new Response(
-		  JSON.stringify({ error: "Internal Server Error", details: errorMessage }),
+		  JSON.stringify({ error: "Internal Server Error" }),
 		  { status: 500, headers: { "Content-Type": "application/json" } }
 		);
 	  }


### PR DESCRIPTION
## Summary
Security hardening for the `my-chatbot` Cloudflare Worker. It previously forwarded `requestData.messages` to OpenAI after only checking it was an array — oversized arrays, arbitrary extra fields, and malformed entries went straight through on the worker's API key — and it echoed raw OpenAI error bodies plus internal exception messages back to clients.

- Rejects payloads outside 1–50 messages with a 400
- Requires each message to have an allowed role (`system`/`user`/`assistant`) and non-empty string content of at most 8,000 characters (the iOS client only ever sends `user` messages, so this is not a behavior change for the app)
- Forwards only the `role`/`content` fields of each message, dropping anything else in the payload
- Logs upstream/internal error detail server-side only; clients now get generic 502/500 bodies instead of raw OpenAI responses and exception messages

Not addressed here (larger changes): authenticating callers / rate limiting the worker — anyone who discovers the endpoint can still consume quota with well-formed requests.

## Testing
- `npx tsc --noEmit` passes
- `esbuild` bundles `src/index.ts` cleanly
- Note: `npm test` fails before and after this change — the installed `@cloudflare/vitest-pool-workers` is incompatible with the installed vitest (`Missing "./config" specifier`), a pre-existing toolchain issue

https://claude.ai/code/session_019Z1uLShTHyrjZg925Hf4NU

---
_Generated by [Claude Code](https://claude.ai/code/session_019Z1uLShTHyrjZg925Hf4NU)_