### PR TITLE
Repair my-chatbot test setup and surface chat errors in the iOS app

### DIFF
--- a/SUSTAINForiOS/ChatController.swift
+++ b/SUSTAINForiOS/ChatController.swift
@@ -14,11 +14,14 @@ class ChatController: ObservableObject {
     let apiURL = "https://my-chatbot.sustain-for-ios.workers.dev"
 
     func sendNewMessage(content: String) {
-        let userMessage = Message(content: content, isUser: true)
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        let userMessage = Message(content: trimmed, isUser: true)
         DispatchQueue.main.async {
             self.messages.append(userMessage)
         }
-        getBotReply(from: content)
+        getBotReply(from: trimmed)
     }
     
     private func getBotReply(from message: String) {
@@ -41,14 +44,18 @@ class ChatController: ObservableObject {
             return
         }
 
-        URLSession.shared.dataTask(with: request) { data, response, error in
+        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            guard let self = self else { return }
+
             if let error = error {
                 print("❌ Request failed: \(error.localizedDescription)")
+                self.appendBotMessage("Sorry, the request failed. Please check your connection and try again.")
                 return
             }
 
             guard let data = data else {
                 print("❌ No response data")
+                self.appendBotMessage("Sorry, no response was received. Please try again.")
                 return
             }
 
@@ -63,8 +70,15 @@ class ChatController: ObservableObject {
                 }
             } catch {
                 print("❌ Failed to decode response: \(error)")
+                self.appendBotMessage("Sorry, something went wrong reading the response. Please try again.")
             }
         }.resume()
+    }
+
+    private func appendBotMessage(_ content: String) {
+        DispatchQueue.main.async {
+            self.messages.append(Message(content: content, isUser: false))
+        }
     }
 }
 

--- a/my-chatbot/test/index.spec.ts
+++ b/my-chatbot/test/index.spec.ts
@@ -1,5 +1,5 @@
 // test/index.spec.ts
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import worker from '../src/index';
 
 // Mock environment for testing
@@ -7,16 +7,91 @@ const mockEnv = {
 	OPENAI_API_KEY: 'test-api-key'
 };
 
-describe('Hello World worker', () => {
-	it('responds with Hello World! (unit style)', async () => {
-		const request = new Request('http://example.com');
-		const response = await worker.fetch(request, mockEnv);
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
+function postRequest(body: unknown): Request {
+	return new Request('https://example.com', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: typeof body === 'string' ? body : JSON.stringify(body)
 	});
+}
 
-	it('responds with Hello World! (integration style)', async () => {
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('Chatbot worker', () => {
+	it('rejects non-POST requests with 405', async () => {
 		const request = new Request('https://example.com');
 		const response = await worker.fetch(request, mockEnv);
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
+		expect(response.status).toBe(405);
+		expect(await response.json()).toEqual({ error: 'Use a POST request.' });
+	});
+
+	it('rejects invalid JSON with 400', async () => {
+		const response = await worker.fetch(postRequest('not json'), mockEnv);
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({ error: 'Invalid JSON format.' });
+	});
+
+	it('rejects a body without a messages array with 400', async () => {
+		const response = await worker.fetch(postRequest({ messages: 'hi' }), mockEnv);
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({
+			error: "Invalid request format. 'messages' must be an array."
+		});
+	});
+
+	it('rejects an empty messages array with 400', async () => {
+		const response = await worker.fetch(postRequest({ messages: [] }), mockEnv);
+		expect(response.status).toBe(400);
+	});
+
+	it('rejects messages with an invalid role with 400', async () => {
+		const response = await worker.fetch(
+			postRequest({ messages: [{ role: 'hacker', content: 'hi' }] }),
+			mockEnv
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it('forwards valid messages and returns the upstream reply', async () => {
+		const upstreamReply = {
+			choices: [{ message: { role: 'assistant', content: 'Hello!' } }]
+		};
+		const fetchSpy = vi.fn(async () =>
+			new Response(JSON.stringify(upstreamReply), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		vi.stubGlobal('fetch', fetchSpy);
+
+		const response = await worker.fetch(
+			postRequest({ messages: [{ role: 'user', content: 'Hi there' }] }),
+			mockEnv
+		);
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual(upstreamReply);
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+		expect(url).toBe('https://api.openai.com/v1/chat/completions');
+		expect((init.headers as Record<string, string>).Authorization).toBe(
+			'Bearer test-api-key'
+		);
+	});
+
+	it('returns 502 when the upstream API fails', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => new Response('upstream broke', { status: 500 }))
+		);
+
+		const response = await worker.fetch(
+			postRequest({ messages: [{ role: 'user', content: 'Hi there' }] }),
+			mockEnv
+		);
+		expect(response.status).toBe(502);
+		expect(await response.json()).toEqual({ error: 'Upstream API error.' });
 	});
 });

--- a/my-chatbot/vitest.config.mts
+++ b/my-chatbot/vitest.config.mts
@@ -1,11 +1,10 @@
-import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config';
+import { cloudflareTest } from '@cloudflare/vitest-pool-workers';
+import { defineConfig } from 'vitest/config';
 
-export default defineWorkersConfig({
-	test: {
-		poolOptions: {
-			workers: {
-				wrangler: { configPath: './wrangler.jsonc' },
-			},
-		},
-	},
+export default defineConfig({
+	plugins: [
+		cloudflareTest({
+			wrangler: { configPath: './wrangler.jsonc' },
+		}),
+	],
 });


### PR DESCRIPTION
## Summary

Review of the Swift sources (static, no Xcode available) plus a real install/build/test pass on the Node/Cloudflare Worker part (`my-chatbot`).

## Worker tests (run for real)

- `npm install` succeeded; `npx vitest run` initially failed at startup: `vitest.config.mts` still imported `defineWorkersConfig` from `@cloudflare/vitest-pool-workers/config`, an entry point that no longer exists with the installed `@cloudflare/vitest-pool-workers@0.13.4` + `vitest@4.1.8`, so the suite could not start at all.
- Migrated the config to the vitest 4 plugin style (`cloudflareTest` plugin + `defineConfig`), matching the package's own v3-to-v4 migration.
- The existing tests were stale scaffold tests asserting `"Hello World!"` against a worker that returns 405/400 JSON. Replaced them with 7 tests covering the worker's real contract: 405 on non-POST, 400 on invalid JSON / missing or invalid `messages` / bad roles, forwarding valid messages upstream (with the auth header from env), and 502 on upstream failure.
- Verified: `npx vitest run` → 7/7 passing; `tsc --noEmit` clean for both `src` and `test` tsconfigs.

## Swift fixes (SUSTAINForiOS/ChatController.swift)

- The `URLSession` completion handler captured `self` strongly; now `[weak self]`.
- Request failures, empty responses, and decode errors only `print`ed to the console, leaving the chat UI silent. They now append a user-visible bot message.
- Empty/whitespace-only messages are no longer sent.

## Notes for maintainers

- No hardcoded secrets found in the repo; the worker correctly reads `OPENAI_API_KEY` from its environment.
- Not verifiable here: Swift compilation and runtime behavior (no Xcode/Swift toolchain in the review environment) — the Swift edits are deliberately minimal, but please build before merging.
- The root-level `src/index.ts` appears to be an older copy of the worker without the validation/error handling that `my-chatbot/src/index.ts` has; consider removing it (left untouched here).

https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5)_